### PR TITLE
Do not use make build-linux on linux

### DIFF
--- a/testprog/Makefile
+++ b/testprog/Makefile
@@ -15,7 +15,7 @@ all: build
 build: $(BINDIR)/$(BINNAME)
 
 $(BINDIR)/$(BINNAME): $(SRC)
-	go build -o '$(BINDIR)'/$(BINNAME) .
+	CGO_ENABLED=0 go build -o '$(BINDIR)'/$(BINNAME) -ldflags '-extldflags "-static"' .
 
 # If go get is run from inside the project directory it will add the dependencies
 # to the go.mod file. To avoid that we change to a directory without a go.mod file

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -29,7 +29,11 @@ esac
 #######################################
 # Testing in a linux container
 #######################################
-make clean && make build-linux
+if [ "$(uname)" == "Linux" ]; then
+   make clean && make build
+else
+   make clean && make build-linux
+fi
 
 ########################################
 # Bash 4 completion tests


### PR DESCRIPTION
If the test is run on linux there is no need to use `gox`.
The binary just needs to be build statically so we can use
it in the containers.