### PR TITLE
Don't run test we know fails on bash 3

### DIFF
--- a/tests/bash/comp-tests.bash
+++ b/tests/bash/comp-tests.bash
@@ -181,7 +181,11 @@ verifyDebug
 
 # Test completion with a redirection
 # https://github.com/spf13/cobra/issues/1334
-verifyRedirect
+if [ $BASH_VERSINFO != 3 ]; then
+   # We know and accept that this fails with bash 3
+   # https://github.com/spf13/cobra/issues/1334
+   verifyRedirect
+fi
 
 # Test descriptions of bash v2
 if [ "$BASHCOMP_VERSION" = bash2 ]; then


### PR DESCRIPTION
To avoid having any test failures at the end of all the test runs