### PR TITLE
Remember error code when running many shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 TESTPROG_DIR := $(CURDIR)/testprog
 
 .PHONY: all
-all: bash fish
+all:
+	@tests/test-all.sh bash fish
 
 .PHONY: build
 build:

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -15,13 +15,20 @@ BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/..; pwd)
 export TESTS_DIR=${BASE_DIR}/tests
 export TESTPROG_DIR=${BASE_DIR}/testprog
 export TESTING_DIR=${BASE_DIR}/testingdir
-SHELL_TYPE=$1
+
+# Run all tests, even if there is a failure.
+# But remember if there was any failure to report it at the end.
+set +e
+GOT_FAILURE=0
+trap "GOT_FAILURE=1" ERR
+
+for SHELL_TYPE in "$@"; do
 
 case "$SHELL_TYPE" in
-bash|fish|zsh)
+bash|fish)
     ;;
 *)
-    echo "Invalid shell to test: $SHELL_TYPE.  Can be: bash|fish|zsh"
+    echo "Invalid shell to test: $SHELL_TYPE.  Can be: bash|fish"
     exit 1
     ;;
 esac
@@ -34,12 +41,6 @@ if [ "$(uname)" == "Linux" ]; then
 else
    make clean && make build-linux
 fi
-
-# Now run all tests, even if there is a failure.
-# But remember if there was any failure to report it at the end.
-set +e
-GOT_FAILURE=0
-trap "GOT_FAILURE=1" ERR
 
 ########################################
 # Bash 5 completion tests
@@ -223,5 +224,6 @@ else
     echo "================================================"
 fi
 
+done
 # Indicate if anything failed during the run
 exit ${GOT_FAILURE}


### PR DESCRIPTION
This propagates an error when we run multiple shells in one go.

For example when running `make` which runs tests for both bash and fish, if there was an error for bash, then fish would not run.  With this change, the tests for both shells will be run and if there is an error in any, the entire test run will return an error code.