### PR TITLE
Add test of performance for bash completion

### DIFF
--- a/testprog/testprog.go
+++ b/testprog/testprog.go
@@ -194,6 +194,23 @@ var dashArgCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {},
 }
 
+// ======================================================
+// Command generates many completions.
+// It can be used to test performance.
+// ======================================================
+var manyCompsCmd = &cobra.Command{
+	Use:   "manycomps",
+	Short: "Outputs a thousand completions",
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var comps []string
+		for i := 0; i < 1000; i++ {
+			comps = append(comps, fmt.Sprintf("%[1]d-comp\tThis is comp %[1]d", i))
+		}
+		return comps, cobra.ShellCompDirectiveDefault
+	},
+	Run: func(cmd *cobra.Command, args []string) {},
+}
+
 func setFlags() {
 	rootCmd.Flags().String("customComp", "", "test custom comp for flags")
 	rootCmd.RegisterFlagCompletionFunc("customComp", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -218,6 +235,7 @@ func main() {
 		subDirCmd,
 		errorCmd,
 		dashArgCmd,
+		manyCompsCmd,
 	)
 
 	prefixCmd.AddCommand(

--- a/tests/bash/comp-test-lib.bash
+++ b/tests/bash/comp-test-lib.bash
@@ -135,6 +135,21 @@ _completionTests_sort() {
    fi
 }
 
+# $1 - The completion to measure
+# $2 - The maximum time to consider it an error
+_completionTests_timing() {
+   TIMEFORMAT=%R
+   timing=$({ time { _completionTests_complete "$1" > /dev/null; } } 2>&1)
+   if (( $(echo "$timing > ${2}" | bc -l) )); then
+      _completionTests_TEST_FAILED=1
+      echo -e "${RED}Processing 1000 completions took ${timing} seconds which is more than the ${2-0.1} seconds limit$NC" 
+      return 1
+   else
+      echo -e "${GREEN}Processing 1000 completions took ${timing} seconds which is less than the ${2-0.1} seconds limit$NC" 
+      return 0
+   fi
+}
+
 # Find the completion function associated with the binary.
 # $1 is the first argument of the line to complete which allows
 # us to find the existing completion function name.

--- a/tests/bash/comp-tests.bash
+++ b/tests/bash/comp-tests.bash
@@ -199,6 +199,9 @@ _completionTests_verifyCompletion "testprog prefix nospace b" "bear bearpaw" nos
 _completionTests_verifyCompletion "testprog prefix nofile b" "bear bearpaw" nofile
 unset COMP_TYPE
 
+# Measure speed of execution without descriptions (for both v1 and v2)
+_completionTests_timing "testprog manycomps " 0.2
+
 # Test descriptions of bash v2
 if [ "$BASHCOMP_VERSION" = bash2 ]; then
 
@@ -269,6 +272,9 @@ bearpaw" nospace
    _completionTests_verifyCompletion "testprog prefix nofile b" "bear
 bearpaw" nofile
    unset COMP_TYPE
+
+   # Measure speed of execution with descriptions
+   _completionTests_timing "testprog manycomps " 0.5
 fi
 
 # This must be the last call.  It allows to exit with an exit code

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -69,7 +69,7 @@ EOF
            -e BASHCOMPV2=1 \
            ${IMAGE} tests/bash/comp-tests.bash
 fi
-
+exit
 ########################################
 # Bash 4 completion tests
 ########################################
@@ -140,7 +140,7 @@ if [ $SHELL_TYPE = bash ]; then
 
    $CONTAINER_ENGINE build -t ${IMAGE} ${BASE_DIR} -f - <<- EOF
       FROM redhat/ubi8
-      RUN yum install -y bash-completion which
+      RUN yum install -y bash-completion which bc
 
       WORKDIR /work
       COPY . .
@@ -190,7 +190,7 @@ fi
 if [ "$(uname)" == "Darwin" ]; then
     echo
     echo "==================================="
-    echo "Attempting completion tests locally"
+    echo "Attempting $SHELL_TYPE completion tests locally"
     echo "==================================="
 
     make clean && make build


### PR DESCRIPTION
The bash completion v2 script is currently very slow.  These tests will help prevent a regression once we've improved the v2 script.

See https://github.com/spf13/cobra/issues/1680

I'll wait until we have improved the script before merging.