### PR TITLE
Avoid using newline as a completion separator

### DIFF
--- a/tests/bash/comp-test-lib.bash
+++ b/tests/bash/comp-test-lib.bash
@@ -188,10 +188,16 @@ _completionTests_complete() {
    # to stderr.
    eval $(_completionTests_findCompletionFunction ${COMP_WORDS[0]}) 2>&1
 
-   # Return the result of the completion.
+   # Return the result of the call to the completion function.
+   # We separate each completion with a space and not a newline; using newlines
+   # was preventing us from detecting empty completions as newlines are stripped
+   # automatically by the sub-shell call to this function.
+   result="$(printf "%s " "${COMPREPLY[@]}")"
+   # remove the last space we inserted ourselves
+   result="${result% }"
    # We use printf instead of echo as the first completion could be -n which
    # would be interpreted as an argument to echo
-   printf "%s\n" "${COMPREPLY[@]}"
+   printf "%s" "${result}"
 }
 
 _completionTests_exit() {

--- a/tests/bash/comp-tests.bash
+++ b/tests/bash/comp-tests.bash
@@ -232,38 +232,23 @@ EOF
    COLUMNS=${COLUMNS-100}
 
    # Test descriptions with ShellCompDirectiveDefault
-   _completionTests_verifyCompletion "testprog prefix default " "bear     (an animal)
-bearpaw  (a dessert)
-dog
-unicorn  (mythical)"
-   _completionTests_verifyCompletion "testprog prefix default b" "bear     (an animal)
-bearpaw  (a dessert)"
+   _completionTests_verifyCompletion "testprog prefix default " "bear     (an animal) bearpaw  (a dessert) dog unicorn  (mythical)"
+   _completionTests_verifyCompletion "testprog prefix default b" "bear     (an animal) bearpaw  (a dessert)"
    _completionTests_verifyCompletion "testprog prefix default bearp" "bearpaw"
 
    # Test descriptions with ShellCompDirectiveNoFileComp
-   _completionTests_verifyCompletion "testprog prefix nofile " "bear     (an animal)
-bearpaw  (a dessert)
-dog
-unicorn  (mythical)" nofile
-   _completionTests_verifyCompletion "testprog prefix nofile b" "bear     (an animal)
-bearpaw  (a dessert)" nofile
+   _completionTests_verifyCompletion "testprog prefix nofile " "bear     (an animal) bearpaw  (a dessert) dog unicorn  (mythical)" nofile
+   _completionTests_verifyCompletion "testprog prefix nofile b" "bear     (an animal) bearpaw  (a dessert)" nofile
    _completionTests_verifyCompletion "testprog prefix nofile bearp" "bearpaw" nofile
 
    # Test descriptions with ShellCompDirectiveNoSpace
-   _completionTests_verifyCompletion "testprog prefix nospace " "bear     (an animal)
-bearpaw  (a dessert)
-dog
-unicorn  (mythical)" nospace
-   _completionTests_verifyCompletion "testprog prefix nospace b" "bear     (an animal)
-bearpaw  (a dessert)" nospace
+   _completionTests_verifyCompletion "testprog prefix nospace " "bear     (an animal) bearpaw  (a dessert) dog unicorn  (mythical)" nospace
+   _completionTests_verifyCompletion "testprog prefix nospace b" "bear     (an animal) bearpaw  (a dessert)" nospace
    _completionTests_verifyCompletion "testprog prefix nospace bearp" "bearpaw" nospace
 
    # Test descriptions with completion of flag values
-   _completionTests_verifyCompletion "testprog --customComp " "firstComp   (the first value)
-secondComp  (the second value)
-forthComp" nofile
-   _completionTests_verifyCompletion "testprog --customComp f" "firstComp  (the first value)
-forthComp" nofile
+   _completionTests_verifyCompletion "testprog --customComp " "firstComp   (the first value) secondComp  (the second value) forthComp" nofile
+   _completionTests_verifyCompletion "testprog --customComp f" "firstComp  (the first value) forthComp" nofile
    _completionTests_verifyCompletion "testprog --customComp fi" "firstComp" nofile
 
    # Measure speed of execution with descriptions
@@ -273,19 +258,15 @@ forthComp" nofile
    # The types are: menu-complete/menu-complete-backward (COMP_TYPE == 37)
    # and insert-completions (COMP_TYPE == 42)
    COMP_TYPE=37
-   _completionTests_verifyCompletion "testprog prefix nospace b" "bear
-bearpaw" nospace
-   _completionTests_verifyCompletion "testprog prefix nofile b" "bear
-bearpaw" nofile
+   _completionTests_verifyCompletion "testprog prefix nospace b" "bear bearpaw" nospace
+   _completionTests_verifyCompletion "testprog prefix nofile b" "bear bearpaw" nofile
 
    # Measure speed of execution with menu-complete with descriptions
    _completionTests_timing "testprog manycomps " 0.2 "menu-complete with descs"
 
    COMP_TYPE=42
-   _completionTests_verifyCompletion "testprog prefix nospace b" "bear
-bearpaw" nospace
-   _completionTests_verifyCompletion "testprog prefix nofile b" "bear
-bearpaw" nofile
+   _completionTests_verifyCompletion "testprog prefix nospace b" "bear bearpaw" nospace
+   _completionTests_verifyCompletion "testprog prefix nofile b" "bear bearpaw" nofile
 
    # Measure speed of execution with insert-completions with descriptions
    _completionTests_timing "testprog manycomps " 0.2 "insert-completions no descs"


### PR DESCRIPTION
When calling the `_completionTests_complete` function in a sub-shell, the trailing newlines are removed by the shell.  Therefore, if the script we are testing mistakenly includes an empty completion at the end, we would not detect that bug.
See https://github.com/spf13/cobra/pull/1691

With this commit, we use a space to separate the completions, so an empty one will be detected (extra space).

With this change we can see the tests failing before https://github.com/spf13/cobra/pull/1691 and start to pass again when https://github.com/spf13/cobra/pull/1691 is applied

/cc @scop