### PR TITLE
Problem running a binary from /tmp on Apple ARM

### DIFF
--- a/tests/bash/comp-tests.bash
+++ b/tests/bash/comp-tests.bash
@@ -164,11 +164,13 @@ _completionTests_verifyCompletion " testprog prefix default u" "unicorn"
 # Test using env variable and ~
 # https://github.com/spf13/cobra/issues/1306
 OLD_HOME=$HOME
-HOME=/tmp
+HOME=$(mktemp -d)
 cp $ROOTDIR/testprog/bin/testprog $HOME/
 # Must use single quotes to keep the environment variable
 _completionTests_verifyCompletion '$HOME/testprog prefix default u' "unicorn"
 _completionTests_verifyCompletion "~/testprog prefix default u" "unicorn"
+rm $HOME/testprog
+rmdir $HOME
 HOME=$OLD_HOME
 
 # An argument starting with dashes

--- a/tests/fish/comp-tests.fish
+++ b/tests/fish/comp-tests.fish
@@ -128,11 +128,13 @@ _completionTests_verifyCompletion " testprog prefix default u" "unicorn	mythical
 # Test using env variable and ~
 # https://github.com/spf13/cobra/issues/1306
 set OLD_HOME $HOME
-set HOME /tmp
+set HOME $(mktemp -d)
 cp $ROOTDIR/testprog/bin/testprog $HOME/
 _completionTests_verifyCompletion '$HOME/testprog prefix default u' "unicorn	mythical"
 # Must use single quotes to keep the environment variable
 _completionTests_verifyCompletion "~/testprog prefix default u" "unicorn	mythical"
+rm $HOME/testprog
+rmdir $HOME
 set HOME $OLD_HOME
 
 # An argument starting with dashes


### PR DESCRIPTION
Apparently, it is not possible to run a binary when it is located on /tmp on an Apple M1.  Or at least I'm not able to.  This PR uses a proper temporary directory instead of using /tmp.
